### PR TITLE
docs: update docs to use correct 'cert' command, not 'certwiz'

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -18,7 +18,7 @@ Inspect a certificate from a file or URL.
 ### Synopsis
 
 ```bash
-certwiz inspect [file|url] [flags]
+cert inspect [file|url] [flags]
 ```
 
 ### Options
@@ -38,24 +38,24 @@ certwiz inspect [file|url] [flags]
 
 ```bash
 # Inspect local certificate file
-certwiz inspect server.crt
-certwiz inspect /path/to/certificate.pem
+cert inspect server.crt
+cert inspect /path/to/certificate.pem
 
 # Inspect remote certificate
-certwiz inspect google.com
-certwiz inspect https://example.com
-certwiz inspect api.example.com:8443
+cert inspect google.com
+cert inspect https://example.com
+cert inspect api.example.com:8443
 
 # With options
-certwiz inspect google.com --full
-certwiz inspect github.com --chain
-certwiz inspect example.com --full --chain
-certwiz inspect internal.service --port 8443
+cert inspect google.com --full
+cert inspect github.com --chain
+cert inspect example.com --full --chain
+cert inspect internal.service --port 8443
 
 # Through proxy or tunnel
-certwiz inspect api.example.com --connect localhost:8080
-certwiz inspect prod.internal --connect tunnel.local --port 443
-certwiz inspect backend.local --connect 127.0.0.1:3000
+cert inspect api.example.com --connect localhost:8080
+cert inspect prod.internal --connect tunnel.local --port 443
+cert inspect backend.local --connect 127.0.0.1:3000
 ```
 
 ### Connect Flag Usage
@@ -105,7 +105,7 @@ Generate a self-signed certificate.
 ### Synopsis
 
 ```bash
-certwiz generate [flags]
+cert generate [flags]
 ```
 
 ### Options
@@ -129,22 +129,22 @@ SANs can be specified as:
 
 ```bash
 # Basic certificate
-certwiz generate --cn myapp.local
+cert generate --cn myapp.local
 
 # With multiple SANs
-certwiz generate --cn myapp.local \
+cert generate --cn myapp.local \
   --san myapp.local \
   --san "*.myapp.local" \
   --san localhost \
   --san IP:127.0.0.1
 
 # Custom validity and key size
-certwiz generate --cn secure.app \
+cert generate --cn secure.app \
   --days 730 \
   --key-size 4096
 
 # Output to specific directory
-certwiz generate --cn myapp.local \
+cert generate --cn myapp.local \
   --output /etc/ssl/certs/
 ```
 
@@ -161,7 +161,7 @@ Convert certificate between PEM and DER formats.
 ### Synopsis
 
 ```bash
-certwiz convert <input> <output> [flags]
+cert convert <input> <output> [flags]
 ```
 
 ### Options
@@ -179,13 +179,13 @@ certwiz convert <input> <output> [flags]
 
 ```bash
 # PEM to DER
-certwiz convert certificate.pem certificate.der --format der
+cert convert certificate.pem certificate.der --format der
 
 # DER to PEM
-certwiz convert certificate.der certificate.pem --format pem
+cert convert certificate.der certificate.pem --format pem
 
 # Auto-detect input format
-certwiz convert input.crt output.der --format der
+cert convert input.crt output.der --format der
 ```
 
 ### Format Detection
@@ -202,7 +202,7 @@ Verify a certificate's validity and optionally check against a hostname.
 ### Synopsis
 
 ```bash
-certwiz verify <certificate> [flags]
+cert verify <certificate> [flags]
 ```
 
 ### Options
@@ -220,16 +220,16 @@ certwiz verify <certificate> [flags]
 
 ```bash
 # Basic verification
-certwiz verify server.crt
+cert verify server.crt
 
 # Verify hostname match
-certwiz verify server.crt --host example.com
+cert verify server.crt --host example.com
 
 # Verify against CA
-certwiz verify server.crt --ca ca-bundle.crt
+cert verify server.crt --ca ca-bundle.crt
 
 # Complete verification
-certwiz verify server.crt \
+cert verify server.crt \
   --host api.example.com \
   --ca /etc/ssl/certs/ca-bundle.crt
 ```
@@ -332,23 +332,23 @@ Generate shell completion scripts.
 ### Synopsis
 
 ```bash
-certwiz completion [bash|zsh|fish|powershell]
+cert completion [bash|zsh|fish|powershell]
 ```
 
 ### Examples
 
 ```bash
 # Bash
-certwiz completion bash > /etc/bash_completion.d/certwiz
+cert completion bash > /etc/bash_completion.d/cert
 
 # Zsh
-certwiz completion zsh > "${fpath[1]}/_certwiz"
+cert completion zsh > "${fpath[1]}/_cert"
 
 # Fish
-certwiz completion fish > ~/.config/fish/completions/certwiz.fish
+cert completion fish > ~/.config/fish/completions/cert.fish
 
 # PowerShell
-certwiz completion powershell | Out-String | Invoke-Expression
+cert completion powershell | Out-String | Invoke-Expression
 ```
 
 ## Environment Variables
@@ -365,14 +365,14 @@ certwiz respects these environment variables:
 
 ```bash
 # Disable colors
-NO_COLOR=1 certwiz inspect google.com
+NO_COLOR=1 cert inspect google.com
 
 # Force colors in pipe
-FORCE_COLOR=1 certwiz inspect google.com | less -R
+FORCE_COLOR=1 cert inspect google.com | less -R
 
 # Set default port
 export CERTWIZ_PORT=8443
-certwiz inspect internal.service
+cert inspect internal.service
 ```
 
 ## Output Formats
@@ -394,13 +394,13 @@ When output is piped, certwiz:
 
 ```bash
 # Search for specific information
-certwiz inspect google.com | grep "Valid To"
+cert inspect google.com | grep "Valid To"
 
 # Save to file
-certwiz inspect example.com --full > cert-details.txt
+cert inspect example.com --full > cert-details.txt
 
 # Process with jq (future JSON support)
-# certwiz inspect example.com --json | jq '.subject'
+# cert inspect example.com --json | jq '.subject'
 ```
 
 ## Advanced Usage
@@ -410,17 +410,17 @@ certwiz inspect example.com --full > cert-details.txt
 ```bash
 # Check multiple domains
 for domain in $(cat domains.txt); do
-  certwiz inspect "$domain" | grep Status
+  cert inspect "$domain" | grep Status
 done
 
 # Generate multiple certificates
 while IFS= read -r domain; do
-  certwiz generate --cn "$domain" --san "$domain"
+  cert generate --cn "$domain" --san "$domain"
 done < domains.txt
 
 # Convert all certificates in directory
 for cert in *.pem; do
-  certwiz convert "$cert" "${cert%.pem}.der" --format der
+  cert convert "$cert" "${cert%.pem}.der" --format der
 done
 ```
 
@@ -428,13 +428,13 @@ done
 
 ```bash
 # With OpenSSL
-certwiz inspect example.com --full | grep -A2 "Key Usage"
+cert inspect example.com --full | grep -A2 "Key Usage"
 
 # With curl
-curl -k https://example.com/cert.pem | certwiz inspect -
+curl -k https://example.com/cert.pem | cert inspect -
 
 # With find
-find /etc/ssl -name "*.crt" -exec certwiz verify {} \;
+find /etc/ssl -name "*.crt" -exec cert verify {} \;
 ```
 
 ### Scripting
@@ -445,7 +445,7 @@ find /etc/ssl -name "*.crt" -exec certwiz verify {} \;
 
 check_cert() {
   local domain=$1
-  local output=$(certwiz inspect "$domain" 2>&1)
+  local output=$(cert inspect "$domain" 2>&1)
   
   if [[ $? -ne 0 ]]; then
     echo "ERROR: Failed to check $domain"

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -10,7 +10,7 @@ Set up HTTPS for local development:
 
 ```bash
 # Generate certificate for local development
-certwiz generate --cn localhost \
+cert generate --cn localhost \
   --san localhost \
   --san "*.localhost" \
   --san myapp.local \
@@ -28,7 +28,7 @@ sudo cp localhost.crt /usr/local/share/ca-certificates/
 sudo update-ca-certificates
 
 # Verify it works
-certwiz verify localhost.crt --host localhost
+cert verify localhost.crt --host localhost
 ```
 
 ### Multi-domain Development Certificate
@@ -37,7 +37,7 @@ Create a certificate for multiple local domains:
 
 ```bash
 # Generate wildcard certificate for development
-certwiz generate --cn "dev.local" \
+cert generate --cn "dev.local" \
   --san "*.dev.local" \
   --san "*.app.local" \
   --san "*.test.local" \
@@ -78,7 +78,7 @@ CRITICAL_DAYS=7
 for domain in "${DOMAINS[@]}"; do
     echo "Checking $domain..."
     
-    output=$(certwiz inspect "$domain" 2>&1)
+    output=$(cert inspect "$domain" 2>&1)
     if [[ $? -ne 0 ]]; then
         echo "❌ ERROR: Cannot connect to $domain"
         continue
@@ -113,7 +113,7 @@ Generate and deploy certificate for Kubernetes:
 
 ```bash
 # Generate certificate
-certwiz generate --cn myapp.example.com \
+cert generate --cn myapp.example.com \
   --san myapp.example.com \
   --san www.myapp.example.com \
   --days 90
@@ -129,7 +129,7 @@ kubectl get secret myapp-tls -n production -o yaml | \
   grep tls.crt | awk '{print $2}' | \
   base64 -d > /tmp/k8s-cert.pem
 
-certwiz inspect /tmp/k8s-cert.pem
+cert inspect /tmp/k8s-cert.pem
 ```
 
 ### Docker Container SSL
@@ -138,7 +138,7 @@ Set up SSL for containerized applications:
 
 ```bash
 # Generate certificate
-certwiz generate --cn docker.local \
+cert generate --cn docker.local \
   --san docker.local \
   --san "*.docker.local" \
   --san IP:172.17.0.1
@@ -152,7 +152,7 @@ docker run -d \
   myapp:latest
 
 # Verify from host
-certwiz inspect docker.local:443
+cert inspect docker.local:443
 ```
 
 ## Security & Compliance
@@ -176,7 +176,7 @@ check_compliance() {
     echo "Auditing: $cert_file"
     
     # Get full certificate details
-    details=$(certwiz inspect "$cert_file" --full)
+    details=$(cert inspect "$cert_file" --full)
     
     # Check key size
     key_info=$(echo "$details" | grep "Public Key" | grep -oE '[0-9]+ bits')
@@ -224,15 +224,15 @@ Verify complete certificate chains:
 domain="secure.example.com"
 
 # Get the certificate and chain
-certwiz inspect $domain --chain > chain-analysis.txt
+cert inspect $domain --chain > chain-analysis.txt
 
 # Extract each certificate
-certwiz inspect $domain --full | grep -A 100 "Certificate Chain" > chain.txt
+cert inspect $domain --full | grep -A 100 "Certificate Chain" > chain.txt
 
 # Verify each link in the chain
 echo "Verifying chain for $domain"
-certwiz verify server.crt --ca intermediate.crt
-certwiz verify intermediate.crt --ca root.crt
+cert verify server.crt --ca intermediate.crt
+cert verify intermediate.crt --ca root.crt
 ```
 
 ## Troubleshooting
@@ -246,16 +246,16 @@ Diagnose connection problems:
 problem_site="https://broken.example.com:8443"
 
 echo "=== Basic Connection Test ==="
-certwiz inspect $problem_site 2>&1
+cert inspect $problem_site 2>&1
 
 echo -e "\n=== Certificate Details ==="
-certwiz inspect $problem_site --full 2>&1
+cert inspect $problem_site --full 2>&1
 
 echo -e "\n=== Certificate Chain ==="
-certwiz inspect $problem_site --chain 2>&1
+cert inspect $problem_site --chain 2>&1
 
 echo -e "\n=== Common Issues to Check ==="
-output=$(certwiz inspect $problem_site 2>&1)
+output=$(cert inspect $problem_site 2>&1)
 
 # Check for expired certificate
 if echo "$output" | grep -q "EXPIRED"; then
@@ -269,7 +269,7 @@ fi
 
 # Check SANs match
 echo -e "\n=== SAN Verification ==="
-certwiz inspect $problem_site | grep -A10 "SANs"
+cert inspect $problem_site | grep -A10 "SANs"
 ```
 
 ### Certificate Migration
@@ -283,14 +283,14 @@ NEW_SERVER="new.server.com"
 
 # Inspect current certificate
 echo "Current certificate on $OLD_SERVER:"
-certwiz inspect $OLD_SERVER
+cert inspect $OLD_SERVER
 
 # After migration, verify new setup
 echo "New certificate on $NEW_SERVER:"
-certwiz inspect $NEW_SERVER
+cert inspect $NEW_SERVER
 
 # Compare certificates
-diff <(certwiz inspect $OLD_SERVER) <(certwiz inspect $NEW_SERVER)
+diff <(cert inspect $OLD_SERVER) <(cert inspect $NEW_SERVER)
 ```
 
 ## API & Microservices
@@ -301,24 +301,24 @@ Set up mutual TLS for microservices:
 
 ```bash
 # Generate CA certificate
-certwiz generate --cn "MicroServices CA" \
+cert generate --cn "MicroServices CA" \
   --days 3650 \
   --key-size 4096
 
 # Generate server certificate
-certwiz generate --cn api.internal \
+cert generate --cn api.internal \
   --san api.internal \
   --san "*.api.internal" \
   --days 365
 
 # Generate client certificate
-certwiz generate --cn client.internal \
+cert generate --cn client.internal \
   --san client.internal \
   --days 365
 
 # Verify the certificates
-certwiz verify api.internal.crt --host api.internal
-certwiz verify client.internal.crt --host client.internal
+cert verify api.internal.crt --host api.internal
+cert verify client.internal.crt --host client.internal
 ```
 
 ### API Gateway Certificate
@@ -327,7 +327,7 @@ Configure API gateway with proper certificates:
 
 ```bash
 # Generate certificate for API gateway
-certwiz generate --cn api.company.com \
+cert generate --cn api.company.com \
   --san api.company.com \
   --san api-v1.company.com \
   --san api-v2.company.com \
@@ -336,7 +336,7 @@ certwiz generate --cn api.company.com \
 
 # Verify certificate covers all endpoints
 for endpoint in api api-v1 api-v2 api-staging; do
-    certwiz verify api.company.com.crt --host $endpoint.company.com
+    cert verify api.company.com.crt --host $endpoint.company.com
 done
 ```
 
@@ -366,10 +366,10 @@ jobs:
           domains="api.example.com www.example.com admin.example.com"
           for domain in $domains; do
             echo "Checking $domain..."
-            certwiz inspect $domain || exit 1
+            cert inspect $domain || exit 1
             
             # Fail if expiring soon
-            output=$(certwiz inspect $domain)
+            output=$(cert inspect $domain)
             if echo "$output" | grep -E "EXPIRING SOON|EXPIRED"; then
               echo "::error::Certificate issue for $domain"
               exit 1
@@ -384,7 +384,7 @@ jobs:
             echo ""
             for domain in api.example.com www.example.com; do
               echo "## $domain"
-              certwiz inspect $domain
+              cert inspect $domain
               echo ""
             done
           } > certificate-report.md
@@ -420,10 +420,10 @@ pipeline {
                     domains.each { domain ->
                         sh """
                             echo "Checking ${domain}..."
-                            certwiz inspect ${domain}
+                            cert inspect ${domain}
                             
                             # Extract days remaining
-                            days=\$(certwiz inspect ${domain} | grep -oE '[0-9]+ days remaining' | awk '{print \$1}')
+                            days=\$(cert inspect ${domain} | grep -oE '[0-9]+ days remaining' | awk '{print \$1}')
                             
                             if [ "\$days" -lt "30" ]; then
                                 echo "WARNING: ${domain} expires in \$days days"
@@ -441,7 +441,7 @@ pipeline {
             }
             steps {
                 sh '''
-                    certwiz generate --cn jenkins.local \
+                    cert generate --cn jenkins.local \
                         --san jenkins.local \
                         --san "*.jenkins.local" \
                         --days 365
@@ -472,13 +472,13 @@ Verify certificates in AWS environment:
 # Check ALB certificates
 for alb in $(aws elbv2 describe-load-balancers --query 'LoadBalancers[*].DNSName' --output text); do
     echo "Checking ALB: $alb"
-    certwiz inspect $alb:443
+    cert inspect $alb:443
 done
 
 # Check CloudFront distributions
 for dist in $(aws cloudfront list-distributions --query 'DistributionList.Items[*].DomainName' --output text); do
     echo "Checking CloudFront: $dist"
-    certwiz inspect $dist
+    cert inspect $dist
 done
 ```
 
@@ -488,7 +488,7 @@ done
 # Check Azure App Service certificates
 az webapp list --query '[].{name:name, url:defaultHostName}' -o tsv | while read name url; do
     echo "Checking $name at $url"
-    certwiz inspect $url
+    cert inspect $url
 done
 ```
 
@@ -500,6 +500,6 @@ gcloud compute ssl-certificates list --format="value(name)" | while read cert; d
     echo "Checking certificate: $cert"
     # Export and check
     gcloud compute ssl-certificates describe $cert --format="get(certificate)" > /tmp/$cert.pem
-    certwiz inspect /tmp/$cert.pem
+    cert inspect /tmp/$cert.pem
 done
 ```

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -47,13 +47,13 @@ Add the export line to your shell configuration (`~/.bashrc`, `~/.zshrc`, etc.)
 
 Use sudo for system-wide installation:
 ```bash
-sudo mv certwiz /usr/local/bin/
+sudo mv cert /usr/local/bin/
 ```
 
 Or install to user directory:
 ```bash
 mkdir -p ~/.local/bin
-mv certwiz ~/.local/bin/
+mv cert ~/.local/bin/
 export PATH=$PATH:~/.local/bin
 ```
 
@@ -71,7 +71,7 @@ For Windows, use Windows Terminal or PowerShell 7+.
 ### How do I check if a certificate is expired?
 
 ```bash
-certwiz inspect example.com
+cert inspect example.com
 ```
 
 Look for the "Status" line - it will show:
@@ -84,9 +84,9 @@ Look for the "Status" line - it will show:
 Yes, multiple ways:
 
 ```bash
-certwiz inspect example.com:8443
-certwiz inspect example.com --port 8443
-certwiz inspect https://example.com:8443
+cert inspect example.com:8443
+cert inspect example.com --port 8443
+cert inspect https://example.com:8443
 ```
 
 ### What does the --full flag show?
@@ -102,7 +102,7 @@ The `--full` flag displays detailed certificate extensions:
 ### How do I see the certificate chain?
 
 ```bash
-certwiz inspect example.com --chain
+cert inspect example.com --chain
 ```
 
 This shows the complete chain from server certificate to root CA.
@@ -122,7 +122,7 @@ Currently, certwiz generates self-signed certificates. CA certificate generation
 Use multiple `--san` flags:
 
 ```bash
-certwiz generate --cn example.com \
+cert generate --cn example.com \
   --san example.com \
   --san www.example.com \
   --san "*.example.com" \
@@ -134,7 +134,7 @@ certwiz generate --cn example.com \
 Yes, prefix IPs with `IP:`:
 
 ```bash
-certwiz generate --cn server.local \
+cert generate --cn server.local \
   --san server.local \
   --san IP:192.168.1.100 \
   --san IP:10.0.0.1 \
@@ -150,7 +150,7 @@ Currently RSA keys with configurable size (2048, 4096 bits). ECDSA support is pl
 By default in the current directory. Use `--output` to specify:
 
 ```bash
-certwiz generate --cn example.com --output /path/to/directory/
+cert generate --cn example.com --output /path/to/directory/
 ```
 
 Files are named: `{cn}.crt` and `{cn}.key`
@@ -198,7 +198,7 @@ With `--ca`:
 ### How do I verify against a custom CA?
 
 ```bash
-certwiz verify server.crt --ca /path/to/ca-bundle.crt
+cert verify server.crt --ca /path/to/ca-bundle.crt
 ```
 
 ### Can I verify self-signed certificates?
@@ -206,7 +206,7 @@ certwiz verify server.crt --ca /path/to/ca-bundle.crt
 Yes, but verification will note that it's self-signed. For full validation, provide the same certificate as the CA:
 
 ```bash
-certwiz verify self-signed.crt --ca self-signed.crt
+cert verify self-signed.crt --ca self-signed.crt
 ```
 
 ## Troubleshooting
@@ -224,7 +224,7 @@ Check:
 This is informational - certwiz still shows certificate details. To verify against a CA:
 
 ```bash
-certwiz verify cert.pem --ca ca-bundle.crt
+cert verify cert.pem --ca ca-bundle.crt
 ```
 
 ### Garbled output or missing colors
@@ -232,10 +232,10 @@ certwiz verify cert.pem --ca ca-bundle.crt
 Check terminal compatibility:
 ```bash
 # Force colors
-FORCE_COLOR=1 certwiz inspect example.com
+FORCE_COLOR=1 cert inspect example.com
 
 # Disable colors
-NO_COLOR=1 certwiz inspect example.com
+NO_COLOR=1 cert inspect example.com
 ```
 
 ### How do I debug connection issues?
@@ -244,13 +244,13 @@ Use combination of flags:
 
 ```bash
 # Full details
-certwiz inspect problematic.site --full
+cert inspect problematic.site --full
 
 # Check chain
-certwiz inspect problematic.site --chain
+cert inspect problematic.site --chain
 
 # Try different port
-certwiz inspect problematic.site --port 8443
+cert inspect problematic.site --port 8443
 ```
 
 ## Integration
@@ -265,7 +265,7 @@ Yes! certwiz is script-friendly:
 Example:
 ```bash
 #!/bin/bash
-if certwiz inspect example.com | grep -q "EXPIRED"; then
+if cert inspect example.com | grep -q "EXPIRED"; then
     echo "Certificate expired!"
     exit 1
 fi

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -17,7 +17,7 @@ certwiz has four main commands:
 The simplest use case - check a website's certificate:
 
 ```bash
-certwiz inspect google.com
+cert inspect google.com
 ```
 
 Output shows:
@@ -30,23 +30,23 @@ Output shows:
 
 ```bash
 # PEM format
-certwiz inspect server.crt
+cert inspect server.crt
 
 # DER format  
-certwiz inspect certificate.der
+cert inspect certificate.der
 
 # Automatic format detection
-certwiz inspect mycert.pem
+cert inspect mycert.pem
 ```
 
 ### Custom Ports
 
 ```bash
 # Specify port explicitly
-certwiz inspect example.com:8443
+cert inspect example.com:8443
 
 # Or use the --port flag
-certwiz inspect example.com --port 8443
+cert inspect example.com --port 8443
 ```
 
 ### View Certificate Chain
@@ -54,7 +54,7 @@ certwiz inspect example.com --port 8443
 See the complete trust chain:
 
 ```bash
-certwiz inspect github.com --chain
+cert inspect github.com --chain
 ```
 
 This shows:
@@ -67,7 +67,7 @@ This shows:
 View all certificate extensions with human-readable formatting:
 
 ```bash
-certwiz inspect google.com --full
+cert inspect google.com --full
 ```
 
 Shows:
@@ -82,10 +82,10 @@ Shows:
 
 ```bash
 # View everything
-certwiz inspect example.com --full --chain
+cert inspect example.com --full --chain
 
 # Check a specific port with full details
-certwiz inspect api.example.com:8443 --full
+cert inspect api.example.com:8443 --full
 ```
 
 ## Generating Certificates
@@ -93,7 +93,7 @@ certwiz inspect api.example.com:8443 --full
 ### Basic Self-Signed Certificate
 
 ```bash
-certwiz generate --cn myapp.local
+cert generate --cn myapp.local
 ```
 
 Creates:
@@ -103,7 +103,7 @@ Creates:
 ### With Subject Alternative Names (SANs)
 
 ```bash
-certwiz generate --cn myapp.local \
+cert generate --cn myapp.local \
   --san myapp.local \
   --san "*.myapp.local" \
   --san localhost \
@@ -115,26 +115,26 @@ certwiz generate --cn myapp.local \
 
 ```bash
 # Valid for 2 years
-certwiz generate --cn myapp.local --days 730
+cert generate --cn myapp.local --days 730
 
 # Valid for 90 days (Let's Encrypt style)
-certwiz generate --cn myapp.local --days 90
+cert generate --cn myapp.local --days 90
 ```
 
 ### Custom Key Size
 
 ```bash
 # 4096-bit RSA key
-certwiz generate --cn myapp.local --key-size 4096
+cert generate --cn myapp.local --key-size 4096
 
 # Default is 2048-bit
-certwiz generate --cn myapp.local --key-size 2048
+cert generate --cn myapp.local --key-size 2048
 ```
 
 ### Specify Output Directory
 
 ```bash
-certwiz generate --cn myapp.local --output /etc/ssl/certs/
+cert generate --cn myapp.local --output /etc/ssl/certs/
 ```
 
 ## Converting Certificates
@@ -142,13 +142,13 @@ certwiz generate --cn myapp.local --output /etc/ssl/certs/
 ### PEM to DER
 
 ```bash
-certwiz convert certificate.pem certificate.der --format der
+cert convert certificate.pem certificate.der --format der
 ```
 
 ### DER to PEM
 
 ```bash
-certwiz convert certificate.der certificate.pem --format pem
+cert convert certificate.der certificate.pem --format pem
 ```
 
 ### Auto-detect Input Format
@@ -157,10 +157,10 @@ certwiz automatically detects the input format:
 
 ```bash
 # Converts to DER if input is PEM
-certwiz convert input.crt output.der --format der
+cert convert input.crt output.der --format der
 
 # Converts to PEM if input is DER
-certwiz convert input.der output.pem --format pem
+cert convert input.der output.pem --format pem
 ```
 
 ## Verifying Certificates
@@ -168,7 +168,7 @@ certwiz convert input.der output.pem --format pem
 ### Basic Verification
 
 ```bash
-certwiz verify server.crt
+cert verify server.crt
 ```
 
 Checks:
@@ -179,7 +179,7 @@ Checks:
 ### Verify Against Hostname
 
 ```bash
-certwiz verify server.crt --host example.com
+cert verify server.crt --host example.com
 ```
 
 Verifies:
@@ -189,7 +189,7 @@ Verifies:
 ### Verify Against CA
 
 ```bash
-certwiz verify server.crt --ca ca-bundle.crt
+cert verify server.crt --ca ca-bundle.crt
 ```
 
 Validates:
@@ -200,7 +200,7 @@ Validates:
 ### Combined Verification
 
 ```bash
-certwiz verify server.crt \
+cert verify server.crt \
   --host api.example.com \
   --ca /etc/ssl/certs/ca-bundle.crt
 ```
@@ -240,7 +240,7 @@ EXPIRED (10 days ago)               # Certificate has expired
 # Check multiple domains quickly
 for domain in google.com github.com cloudflare.com; do
   echo "=== $domain ==="
-  certwiz inspect $domain | grep -E "Status|Valid"
+  cert inspect $domain | grep -E "Status|Valid"
 done
 ```
 
@@ -248,17 +248,17 @@ done
 
 ```bash
 # Save certificate to file
-certwiz inspect example.com > example.com.info.txt
+cert inspect example.com > example.com.info.txt
 ```
 
 ### Check Internal Services
 
 ```bash
 # Check internal service with self-signed cert
-certwiz inspect internal.service.local:8443
+cert inspect internal.service.local:8443
 
 # Verify against internal CA
-certwiz verify internal.crt --ca /path/to/internal-ca.crt
+cert verify internal.crt --ca /path/to/internal-ca.crt
 ```
 
 ### Batch Certificate Generation
@@ -266,7 +266,7 @@ certwiz verify internal.crt --ca /path/to/internal-ca.crt
 ```bash
 # Generate certificates for multiple domains
 for domain in app1.local app2.local app3.local; do
-  certwiz generate --cn $domain --san $domain --san "*.$domain"
+  cert generate --cn $domain --san $domain --san "*.$domain"
 done
 ```
 
@@ -278,7 +278,7 @@ done
 domains=("example.com" "api.example.com" "www.example.com")
 
 for domain in "${domains[@]}"; do
-  output=$(certwiz inspect $domain | grep Status)
+  output=$(cert inspect $domain | grep Status)
   if [[ $output == *"EXPIRING SOON"* ]] || [[ $output == *"EXPIRED"* ]]; then
     echo "ALERT: $domain - $output"
   fi
@@ -291,7 +291,7 @@ done
 
 ```bash
 # 1. Generate a certificate for local development
-certwiz generate --cn myapp.local \
+cert generate --cn myapp.local \
   --san myapp.local \
   --san "*.myapp.local" \
   --san localhost \
@@ -302,39 +302,39 @@ sudo mv myapp.local.crt /usr/local/etc/ssl/certs/
 sudo mv myapp.local.key /usr/local/etc/ssl/private/
 
 # 3. Verify the certificate
-certwiz verify /usr/local/etc/ssl/certs/myapp.local.crt --host myapp.local
+cert verify /usr/local/etc/ssl/certs/myapp.local.crt --host myapp.local
 ```
 
 ### Debugging SSL Issues
 
 ```bash
 # 1. Check the problematic certificate
-certwiz inspect problematic-site.com --full
+cert inspect problematic-site.com --full
 
 # 2. View the certificate chain
-certwiz inspect problematic-site.com --chain
+cert inspect problematic-site.com --chain
 
 # 3. Check specific port if non-standard
-certwiz inspect problematic-site.com:8443
+cert inspect problematic-site.com:8443
 
 # 4. Save details for analysis
-certwiz inspect problematic-site.com --full --chain > cert-analysis.txt
+cert inspect problematic-site.com --full --chain > cert-analysis.txt
 ```
 
 ### Certificate Renewal Process
 
 ```bash
 # 1. Check current certificate
-certwiz inspect mysite.com
+cert inspect mysite.com
 
 # 2. Generate new certificate
-certwiz generate --cn mysite.com --san mysite.com --san www.mysite.com
+cert generate --cn mysite.com --san mysite.com --san www.mysite.com
 
 # 3. Verify new certificate
-certwiz verify mysite.com.crt --host mysite.com
+cert verify mysite.com.crt --host mysite.com
 
 # 4. Convert if needed
-certwiz convert mysite.com.crt mysite.com.der --format der
+cert convert mysite.com.crt mysite.com.der --format der
 ```
 
 ## Next Steps


### PR DESCRIPTION
Updating what appears to be old reference to the certwiz command, which is now 'cert', keeping the utility named certwiz.